### PR TITLE
feat: definable channels to bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,13 @@
 
 # 📖 Table of contents
 
-1. [Demo](#-demo)
-2. [Installation](#-installation)
-3. [Usage](#-usage)
+1. [Installation](#-installation)
+1. [Usage](#-usage)
     1. [Changing the delay](#changing-the-delay)
-    2. [Specify the channels to bundle](#specify-the-channels-to-bundle)
-4. [Contributing](#-contributing)
-5. [License](#-license)
-6. [OWOW](#-owow)
-
-## 🚀 Demo
-
-TODO
+    1. [Specify the channels to bundle](#specify-the-channels-to-bundle)
+[Contributing](#-contributing)
+1. [License](#-license)
+1. [OWOW](#-owow)
 
 ## ⚙️ Installation
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 2. [Installation](#-installation)
 3. [Usage](#-usage)
     1. [Changing the delay](#changing-the-delay)
+    2. [Specify the channels to bundle](#specify-the-channels-to-bundle)
 4. [Contributing](#-contributing)
 5. [License](#-license)
 6. [OWOW](#-owow)
@@ -136,6 +137,17 @@ public function withDelay(object $notifiable): array
         'mail' => 30,
         'sms' => 60,
     ];
+}
+```
+
+### Specify the channels to bundle
+
+By default, all channels are bundled. You can change this by using the `bundleChannels()` method.
+
+```php
+public function bundleChannels(): array
+{
+    return ['mail'];
 }
 ```
 

--- a/src/Middleware/BundlesNotifications.php
+++ b/src/Middleware/BundlesNotifications.php
@@ -29,6 +29,12 @@ class BundlesNotifications
         $channel = $job->channels[0];
         $identifier = $notification->bundleIdentifier($this->notifiable);
 
+        if (method_exists($notification, 'bundleChannels')) {
+            if (! in_array($channel, $notification->bundleChannels())) {
+                return $next($job);
+            }
+        }
+
         $notificationBundleQuery = NotificationBundle::query()
             ->where('channel', $channel)
             ->where('bundle_identifier', $identifier);

--- a/src/NotificationBundlerServiceProvider.php
+++ b/src/NotificationBundlerServiceProvider.php
@@ -22,6 +22,13 @@ class NotificationBundlerServiceProvider extends ServiceProvider
             $notifiable = $event->job->notifiables->first();
             /** @var ShouldBundleNotifications $notification */
             $notification = $event->job->notification;
+            $channel = $event->job->channels[0];
+
+            if (method_exists($notification, 'bundleChannels')) {
+                if (! in_array($channel, $notification->bundleChannels())) {
+                    return;
+                }
+            }
 
             NotificationBundle::create([
                 'uuid' => $event->job->notification->id,

--- a/tests/.pest/snapshots/Feature/SingleUser/BundledTest/_single_user_bundled_mail_notification__→_it_can_define_on_which_channel_a_notification_should_be_bundled.snap
+++ b/tests/.pest/snapshots/Feature/SingleUser/BundledTest/_single_user_bundled_mail_notification__→_it_can_define_on_which_channel_a_notification_should_be_bundled.snap
@@ -1,0 +1,10 @@
+[Laravel](http://localhost)
+
+# Hello!
+
+Robin was unbundled.
+
+Regards,
+Laravel
+
+© 2023 Laravel. All rights reserved.

--- a/tests/.pest/snapshots/Feature/SingleUser/BundledTest/_single_user_bundled_mail_notification__→_it_can_define_on_which_channel_a_notification_should_be_bundled__2.snap
+++ b/tests/.pest/snapshots/Feature/SingleUser/BundledTest/_single_user_bundled_mail_notification__→_it_can_define_on_which_channel_a_notification_should_be_bundled__2.snap
@@ -1,0 +1,10 @@
+[Laravel](http://localhost)
+
+# Hello!
+
+Pieter was unbundled.
+
+Regards,
+Laravel
+
+© 2023 Laravel. All rights reserved.

--- a/tests/Support/UnBundledMailNotification.php
+++ b/tests/Support/UnBundledMailNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Owowagency\NotificationBundler\Tests\Support;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Owowagency\NotificationBundler\BundlesNotifications;
+use Owowagency\NotificationBundler\ShouldBundleNotifications;
+
+class UnBundledMailNotification extends Notification implements ShouldBundleNotifications, ShouldQueue
+{
+    use BundlesNotifications, Queueable;
+
+    public function __construct(public string $name)
+    {
+        //
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function bundleChannels(): array
+    {
+        return [];
+    }
+
+    public function toMail(object $notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Bundle')
+            ->line("$this->name was unbundled.");
+    }
+
+    public function bundleIdentifier(object $notifiable): string
+    {
+        return "user_$notifiable->id";
+    }
+}


### PR DESCRIPTION
Add the ability to define which channels should be bundled

Usage:

```php
public function bundleChannels(): array
{
    return ['mail'];
}
```